### PR TITLE
Update Yoast Selectors

### DIFF
--- a/css/hide-ai-styles.css
+++ b/css/hide-ai-styles.css
@@ -132,7 +132,9 @@
 		}
 
 		/* "Generate" buttons in SEO title and Meta description area */
-		.yst-root button.yst-replacevar__use-ai-button {
+		.yst-root button.yst-replacevar__use-ai-button,
+		.yst-root button[id^=yst-replacevar__use-ai-button],
+		.yst-root:has(>button[id^=yst-replacevar__use-ai-button]:only-child) {
 			display: none !important;
 		}
 


### PR DESCRIPTION
Hides the following Yoast AI buttons

<img width="913" height="736" alt="Screenshot 2026-05-26 at 5 16 20 PM" src="https://github.com/user-attachments/assets/ef0a9693-cd3b-49ad-b989-285f2120e7ee" />

It seems the classname was moved to an ID with the format `yst-replacevar__use-ai-button__{id}`.

We could also/instead target the '.yst-button--ai-secondary' modifier classname, but targeting the ID gives context.

Additionally, we target the parent yst-root using the following compound selector: `.yst-root:has(>button[id^=yst-replacevar__use-ai-button]:only-child)` otherwise the gap is not removed and a space is left to the right of the remaining button.